### PR TITLE
Added revisions schema, revision retrieval and updating

### DIFF
--- a/server/controllers/docHandlers.js
+++ b/server/controllers/docHandlers.js
@@ -83,7 +83,11 @@ const updateDoc = (req, res) => {
         Doc.updateOne({_id:revision.doc_id}, { $push:{revisions:revision._id}, content:req.body.textField}, function(docErr, result){
           if (docErr) {
             res.status(500).json({error:"Unable to save this document"});
-            Revision.deleteOne({_id:revision._id});
+            Revision.deleteOne({_id:revision._id}, function(err){
+              if (err) {
+                console.log("Error deleting revision after failed update");
+              }
+            });
           }
           else {
             res.status(200).json({msg:"Document has been saved"});
@@ -107,7 +111,7 @@ const deleteDoc = (req, res) => {
       else {
         Revision.deleteMany({_id:{$in:document.revisions}}, function(err){
           if (err) {
-            console.log("Error deleting revisions");
+            console.log("Error deleting revisions after document deletion");
           }
         }); 
         res.status(200).json({msg:"Document has been deleted"});

--- a/server/controllers/docHandlers.js
+++ b/server/controllers/docHandlers.js
@@ -1,6 +1,7 @@
 const Doc = require('../database/models/doc');
 const Taboo = require('../database/models/taboo');
 const authentication = ('../authentication');
+const Revision = require('../database/models/revision');
 
 const createDoc = (req, res) => {
   if(!req.isAuthenticated()){
@@ -10,6 +11,7 @@ const createDoc = (req, res) => {
     let docinst = new Doc({
       title: req.body.title,
       content: req.body.content,
+      original_content: req.body.content,
       owner_id: req.user._id,
       locked: false,
     });
@@ -31,7 +33,20 @@ const retrieveDoc = (req, res) => {
       return res.status(404).json({error:"Unable to retrieve your document"});
     }
     if (result) {
-      res.status(200).json({document:result});
+      if (req.body.revisionId) {
+        result.getVersion(req.body.revisionId, function(versionErr, versionResult) {
+          if (versionErr || !versionResult) {
+            return res.status(404).json(versionErr);
+          }
+          if (versionResult) {
+            result.content = versionResult.changes
+            res.status(200).json({document:result});
+          }
+        });
+      }
+      else {
+        res.status(200).json({document:result});
+      }
     }
   });
 };
@@ -52,32 +67,53 @@ const updateDoc = (req, res) => {
     res.redirect('/');
   }
   else {
-    // push entire text field into revisions array
+    // add entire text field into revision collection
+    // push revision id to revisions array
     // TODO : change in future to only store changes
-    Doc.updateOne({_id:req.params.documentId}, { $push: {revisions:req.body.textField}}, function(err, result){
+    let revisionInst = new Revision({
+      doc_id: req.params.documentId,
+      changes: req.body.textField,
+      modifier_id: req.user._id
+    });
+    revisionInst.save(function(err, revision){
       if (err) {
         res.status(500).json({error:"Unable to save this document"});
       }
       else {
-        res.status(200).json({msg:"Document has been saved"});
+        Doc.updateOne({_id:revision.doc_id}, { $push:{revisions:revision._id}, content:req.body.textField}, function(docErr, result){
+          if (docErr) {
+            res.status(500).json({error:"Unable to save this document"});
+            Revision.deleteOne({_id:revision._id});
+          }
+          else {
+            res.status(200).json({msg:"Document has been saved"});
+          }
+        });
       }
     });
   }
 };
+
 const deleteDoc = (req, res) => {
   if(!req.isAuthenticated()){
     res.redirect('/');
   }
   else {
     // TODO: only delete if user owns document?
-    Doc.deleteOne({_id:req.params.documentId}, function(err){
+    Doc.findOneAndDelete({_id:req.params.documentId}, function(err, document){
       if (err) {
         res.status(500).json({error:"Unable to delete this document"});
       }
       else {
+        Revision.deleteMany({_id:{$in:document.revisions}}, function(err){
+          if (err) {
+            console.log("Error deleting revisions");
+          }
+        }); 
         res.status(200).json({msg:"Document has been deleted"});
       }
     });
   }
-}
+};
+
 module.exports = {createDoc, retrieveDoc, getDocList, updateDoc, deleteDoc};

--- a/server/database/models/doc.js
+++ b/server/database/models/doc.js
@@ -37,13 +37,13 @@ DocSchema.methods.findAllTabooIdx = function(cb){
 
 DocSchema.methods.getVersion = function(revisionId, cb){
   if (this.revisions.indexOf(revisionId) < 0 ) {
-    return cb({err:"Could not retrieve document version"});
+    return cb({error:"Could not retrieve document version"});
   }
   // Apply changes and call cb with correct content
   // Currently returns the changes of revision since we store the entire content
   Revisions.findById(revisionId, "changes", function(err, result){
     if (err) {
-      return cb({err:"Could not retrieve document version"});
+      return cb({error:"Could not retrieve document version"});
     }
     cb(null, result);
   }); 

--- a/server/database/models/doc.js
+++ b/server/database/models/doc.js
@@ -2,13 +2,15 @@ const mongoose = require('mongoose');
 mongoose.promise = Promise;
 const Schema = mongoose.Schema;
 const TabooWords = require('./taboo');
+const Revisions = require('./revision');
 
 const DocSchema = new Schema({
   title: {type: String, required:true},
   content: {type: String, default:''},
+  original_content: {type: String, default:''},
   owner_id: {type: Schema.Types.ObjectId, ref: 'User'},
   locked: Boolean,
-  revisions: [Schema.Types.Mixed],
+  revisions: [{type: Schema.Types.ObjectId, ref: 'Revision'}],
   date_created: {type: Date, default: Date.now}
 });
 
@@ -33,5 +35,18 @@ DocSchema.methods.findAllTabooIdx = function(cb){
   });
 };
 
+DocSchema.methods.getVersion = function(revisionId, cb){
+  if (this.revisions.indexOf(revisionId) < 0 ) {
+    return cb({err:"Could not retrieve document version"});
+  }
+  // Apply changes and call cb with correct content
+  // Currently returns the changes of revision since we store the entire content
+  Revisions.findById(revisionId, "changes", function(err, result){
+    if (err) {
+      return cb({err:"Could not retrieve document version"});
+    }
+    cb(null, result);
+  }); 
+};
 const doc = mongoose.model('Document', DocSchema); 
 module.exports = doc;

--- a/server/database/models/revision.js
+++ b/server/database/models/revision.js
@@ -1,0 +1,13 @@
+const mongoose = require('mongoose');
+mongoose.promise = Promise;
+const Schema = mongoose.Schema;
+
+const RevisionSchema = new Schema({
+  doc_id: {type: Schema.Types.ObjectId, ref:'Document'},
+  changes: Schema.Types.Mixed,
+  date_created: {type: Date, default: Date.now},
+  modifier_id: {type: Schema.Types.ObjectId, ref: 'User'}
+});
+
+const revision = mongoose.model('Revision', RevisionSchema); 
+module.exports = revision;


### PR DESCRIPTION
Revisions array (contains revision ids) is returned upon document retrieval.
The revisions array maintains chronological order, so the first update of the document is revisions[0], the second update is revisions[1]...
To specify a version of the document to retrieve, POST to /api/docs/retrieve/:documentId with revisionId=? in body.
When revisionId isn't specified, retrieves current version.
This can be changed to a GET in the future. 

Revisions are tracked upon updating a document, deleted upon deleting a document.
For now entire text is saved to revision, will change later to only store changes.